### PR TITLE
Remove dependency on go-cmp

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/peterbourgon/ctxdata"
 )
 
@@ -86,7 +86,7 @@ func TestCallstack(t *testing.T) {
 	want := map[string]string{"inner": "a", "middleware": "b", "outer": "c"}
 	var have map[string]string
 	json.NewDecoder(&buf).Decode(&have)
-	if !cmp.Equal(want, have) {
+	if !reflect.DeepEqual(want, have) {
 		t.Fatalf("want %v, have %v", want, have)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/peterbourgon/ctxdata
 
 go 1.12
-
-require github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
-github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
Hey,

Couldn't see a reason for using `github.com/google/go-cmp/cmp.Equal()` over `reflect.DeepEqual()`. Switching these out removes a dependency and I'm all about that.

Hopefully I haven't missed some obvious reason :)